### PR TITLE
Setup for Heroku deployment

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,7 +96,7 @@ Talking about the BodyApps Web Service it is developed in complete JavaScript us
 
 | Variable Name | Meaning |
 |---------------|---------|
-| MONGO_URI | URI of MongoDB to connect to, e.g. "mongodb://localhost/bodyapps-service" |
+| MONGODB_URI | URI of MongoDB to connect to, e.g. "mongodb://localhost/bodyapps-service" |
 | SMTP_USER | GMail account to use for sending emails |
 | SMTP_PASS | Matching password |
 | GOOGLE_CLIENT_ID | Google client ID obtained from Google Developer Console |
@@ -214,7 +214,7 @@ On a dedicated server, we can simply set the variables in file called `~/.bodyap
 
 ```bash
 # /home/bodyapps/.bodyappsrc
-export MONGO_URI='mongodb://localhost/bodyapps-service'
+export MONGODB_URI='mongodb://localhost/bodyapps-service'
 export SMTP_USER='liamg@gmail.com'
 export SMTP_PASS='...'
 export GOOGLE_CLIENT_ID='...'

--- a/app.json
+++ b/app.json
@@ -1,0 +1,34 @@
+{
+  "name": "bodyapps",
+  "description": "Fashiontec Bodyapps Backend Service",
+  "website": "http://freelayers.org/",
+  "repository": "https://github.com/fossasia/bodyapps-web",
+  "env": {
+    "SMTP_USER": {
+      "require": true
+    },
+    "SMTP_PASSWORD": {
+      "require": true
+    },
+    "GOOGLE_CLIENT_ID": {
+      "require": true
+    },
+    "GOOGLE_CLIENT_SECRET": {
+      "require": true
+    }
+  },
+  "formation": {
+    "web": {
+      "quantity": 1,
+      "size": "Free"
+    }
+  },
+  "addons": [
+    "mongolab:sandbox"
+  ],
+  "buildpacks": [
+    {
+      "url": "heroku/nodejs"
+    }
+  ]
+}

--- a/app/config.js
+++ b/app/config.js
@@ -3,7 +3,7 @@ var env = process.env;
 var config = module.exports = {
 
   mongo: {
-    uri: env.MONGO_URI || 'mongodb://localhost/bodyapps-service-test',
+    uri: env.MONGODB_URI || 'mongodb://localhost/bodyapps-service-test',
   },
 
   google_oauth: {

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "lodash": "^2.4.1",
     "method-override": "^2.1.3",
     "moment": "^2.8.1",
-    "mongoose": "3.8.12",
+    "mongoose": "^4.6.4",
     "mongoose-session": "0.0.1",
     "morgan": "^1.1.1",
     "node-ee-mime-magic": "^0.1.1",
@@ -52,7 +52,8 @@
     "supertest": "^0.13.0"
   },
   "scripts": {
-    "start": "grunt s",
+    "dev": "grunt s",
+    "start": "node ./server.js",
     "test": "grunt api-test"
   }
 }


### PR DESCRIPTION
Why:
- We want to deploy the master branch automatically to an Heroku
  application;
- We want to deploy each branch automatically to a new review app when a
  new PR is created.

This change addresses the need by:
- Refactoring the Node package descriptor to use `npm start` simply to
  start the server (as expected by convention), and `npm run dev` to
  start the development environment server (with watches). This is the
  expected behaviour on Heroku, and [is recommended by NPM](https://www.youtube.com/watch?v=zWEU8kNKi3Q);
- Upgrading Mongoose to a version compatible with
  [mLab MongoDB addon on Heroku](https://elements.heroku.com/addons/mongolab);
- Refactoring the MongoDB connection string variable to the default used
  the MongoDB addon;
- Adding an application manifest to describe how the Heroku application
  for each PR should be created.

Fixes #60
